### PR TITLE
Fix pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- fix pagination handling when next/previous are missing
 
 ## [1.3.0] - 2023-03-23
 ### Added
 - add `next()`, `prev()` and `iterator()` methods for paginated
   responses to make page browsing easier
-  
+
 ## [1.2.0-beta] - 2023-02-17
 ### Added
 - first experimental release to the PyPI - versioning not yet fully synced with Component Registry

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -160,4 +160,4 @@ Which can then be converted to a dictionary.
 single_response_dict = single_response.to_dict()
 ```
 
-Each paginated response comes also with pagination helpers which allows user to conveniently browse through all the pages without the need to adjust offset or limit. These methods are `.next()`, `.prev()` for basic navigation in both directions and .iterator()` which returns iterable enabling looping through the responses in for loop.
+Each paginated response comes also with pagination helpers which allows user to conveniently browse through all the pages without the need to adjust offset or limit. These methods are `.next()`, `.prev()` for basic navigation in both directions and `.iterator` which returns iterable enabling looping through the responses in for loop.

--- a/component_registry_bindings/session.py
+++ b/component_registry_bindings/session.py
@@ -144,7 +144,7 @@ class SessionOperationsGroup:
             kwargs.pop("limit", None)
             kwargs.pop("offset", None)
             param = getattr(response, param_name, None)
-            if param is None:
+            if param in (None, UNSET):
                 setattr(response, func_name, lambda: None)
             else:
                 limit = re.search("limit=(\d+)", param)


### PR DESCRIPTION
Some retrieve list endpoints in Component Registry does not return previous/next fields and thus pagination handler fails. This PR fixes this by proper checking for previous/next fields in response.