### PR TITLE
Asynchronous calls tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- operation for results count
+- max_results parameter for `retrieve_list_iterator_async`
+- settable maximum concurrent connections via `COMPONENT_REGISTRY_BINDINGS_MAX_CONCURRENCY`
+  environmental variable
 ## [1.3.6] - 2023-08-22
 ### Added
 - implement async iterator operation

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -121,6 +121,8 @@ By default there is a limit which allows up to 10 concurrent connections. This l
 export COMPONENT_REGISTRY_BINDINGS_MAX_CONCURRENCY=30
 ```
 
+Using the argument `max_results` you can limit the number of results returned.
+
 See `/GET /api/{api_version}/components` in [API docs](openapi_schema.yml) for more details (query parameters, response format, etc.)
 ```python
   all_components = session.components.retrieve_list_iterator_async()
@@ -128,6 +130,10 @@ See `/GET /api/{api_version}/components` in [API docs](openapi_schema.yml) for m
     do_calc(component)
 
   for component in session.components.retrieve_list_iterator_async(arch="x86_64"):
+    print(component.arch)
+
+  # print the first 200 results
+  for component in session.components.retrieve_list_iterator_async(max_results=200):
     print(component.arch)
 ```
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -115,6 +115,12 @@ See `/GET /api/{api_version}/components` in [API docs](openapi_schema.yml) for m
 Retrieve a list of Components. Handles the pagination and returns the generator of individual resource entities. Uses asynchronous communitation
 to speed up the data retrieval.
 
+By default there is a limit which allows up to 10 concurrent connections. This limit can be changed by setting the `COMPONENT_REGISTRY_BINDINGS_MAX_CONCURRENCY` environmental variable. It is strongly recommended to keep this limit between 1-50 concurrent connections. Exceeding this limit may cause service overload which might by considered as the Denial-of-Service attack.
+
+```python
+export COMPONENT_REGISTRY_BINDINGS_MAX_CONCURRENCY=30
+```
+
 See `/GET /api/{api_version}/components` in [API docs](openapi_schema.yml) for more details (query parameters, response format, etc.)
 ```python
   all_components = session.components.retrieve_list_iterator_async()
@@ -124,6 +130,10 @@ See `/GET /api/{api_version}/components` in [API docs](openapi_schema.yml) for m
   for component in session.components.retrieve_list_iterator_async(arch="x86_64"):
     print(component.arch)
 ```
+
+#### components.count
+
+Retrieve the the total count number of entities which would be returned by the same `retrieve_list` call. In terms of the input arguments this operation behaves the same as `retrieve_list`.
 
 #### components.retrieve
 

--- a/component_registry_bindings/constants.py
+++ b/component_registry_bindings/constants.py
@@ -12,6 +12,9 @@ COMPONENT_REGISTRY_BINDINGS_USERAGENT: str = (
 COMPONENT_REGISTRY_BINDINGS_API_PATH: str = (
     f".bindings.python_client.api.{COMPONENT_REGISTRY_API_VERSION}"
 )
+COMPONENT_REGISTRY_BINDINGS_PLACEHOLDER_FIELD = (
+    f'__placeholder_field{COMPONENT_REGISTRY_BINDINGS_VERSION.replace(".","")}'
+)
 
 # all available session operations
 ALL_SESSION_OPERATIONS: List[str] = (

--- a/component_registry_bindings/helpers.py
+++ b/component_registry_bindings/helpers.py
@@ -1,0 +1,39 @@
+"""
+component-registry-bindings helpers
+"""
+import json
+from distutils.util import strtobool
+from os import getenv
+from typing import Any, Union
+
+from .exceptions import ComponentRegistryBindingsException
+
+
+def get_env(
+    key: str,
+    default: Union[None, str] = None,
+    is_bool: bool = False,
+    is_int: bool = False,
+    is_json: bool = False,
+) -> Any:
+    """get environment variable"""
+    if (is_bool and is_int) or (is_bool and is_json) or (is_int and is_json):
+        raise ComponentRegistryBindingsException(
+            "Expected environment variable cannot be of multiple types at the same time"
+        )
+
+    value = getenv(key, default)
+    # consider empty string as empty value
+    # as setting the value to non-existing env variable
+    # in compose.yml results in an empty string
+    if value == "":
+        value = default
+
+    if is_bool:
+        value = bool(strtobool(value))
+    if is_int:
+        value = int(value)
+    if is_json:
+        value = json.loads(value)
+
+    return value

--- a/component_registry_bindings/iterators.py
+++ b/component_registry_bindings/iterators.py
@@ -1,5 +1,5 @@
 """
-component-registry iterators
+component-registry-bindings iterators
 """
 
 import re

--- a/component_registry_bindings/session.py
+++ b/component_registry_bindings/session.py
@@ -15,6 +15,7 @@ from .constants import (
     ALL_SESSION_OPERATIONS,
     COMPONENT_REGISTRY_API_VERSION,
     COMPONENT_REGISTRY_BINDINGS_API_PATH,
+    COMPONENT_REGISTRY_BINDINGS_PLACEHOLDER_FIELD,
     COMPONENT_REGISTRY_BINDINGS_USERAGENT,
     RESOURCE_TO_MODEL_MAPPING,
 )
@@ -227,6 +228,21 @@ class SessionOperationsGroup:
             self.__raise_operation_unsupported("delete")
 
     # Extra operations
+
+    def count(self, *args, **kwargs):
+        if "list" in self.allowed_operations:
+            method_module = self.__get_method_module(
+                resource_name=self.resource_name, method="list"
+            )
+            sync_fn = get_sync_function(method_module)
+            kwargs.pop("offset", None)
+            kwargs["limit"] = 1
+            kwargs["include_fields"] = COMPONENT_REGISTRY_BINDINGS_PLACEHOLDER_FIELD
+
+            response = sync_fn(*args, client=self.client, **kwargs)
+            return response.count
+        else:
+            self.__raise_operation_unsupported("retrieve_list")
 
     def search(self, searched_text: str):
         if "search" in self.allowed_operations:


### PR DESCRIPTION
This PR adds:

- settable maximum number of concurrent API calls
- settable maximum results from `retrieve_list_iterator_async`
- helper operation for obtaining the results count