### PR TITLE
Fix to_dict transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - fix usage of query parameters with double underscore
+- fix `to_dict` not being able corretly transform UNSET values
+  of different instances (mainly multiprocessing issue)
 
 ## [1.3.9] - 2023-08-25
 ### Changed
 - fix bindings making lot a of uncessary calls when supplying max_results
-  parameter for async list iterator which is much higher than actual results count 
+  parameter for async list iterator which is much higher than actual results count
 
 ## [1.3.8] - 2023-08-25
 ### Changed

--- a/component_registry_bindings/bindings/python_client/models/authentication_status_retrieve_response_200.py
+++ b/component_registry_bindings/bindings/python_client/models/authentication_status_retrieve_response_200.py
@@ -23,11 +23,11 @@ class AuthenticationStatusRetrieveResponse200(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if oidc_enabled is not UNSET:
+        if not isinstance(oidc_enabled, Unset):
             field_dict["oidc_enabled"] = oidc_enabled
-        if user is not UNSET:
+        if not isinstance(user, Unset):
             field_dict["user"] = user
-        if auth is not UNSET:
+        if not isinstance(auth, Unset):
             field_dict["auth"] = auth
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/channel.py
+++ b/component_registry_bindings/bindings/python_client/models/channel.py
@@ -94,29 +94,29 @@ class Channel(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if last_changed is not UNSET:
+        if not isinstance(last_changed, Unset):
             field_dict["last_changed"] = last_changed
-        if created_at is not UNSET:
+        if not isinstance(created_at, Unset):
             field_dict["created_at"] = created_at
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if relative_url is not UNSET:
+        if not isinstance(relative_url, Unset):
             field_dict["relative_url"] = relative_url
-        if type is not UNSET:
+        if not isinstance(type, Unset):
             field_dict["type"] = type
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/component.py
+++ b/component_registry_bindings/bindings/python_client/models/component.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Tuple, Type, TypeVar, cast
+from typing import Any, Dict, List, Tuple, Type, TypeVar, Union, cast
 
 import attr
 
@@ -177,77 +177,77 @@ class Component(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if download_url is not UNSET:
+        if not isinstance(download_url, Unset):
             field_dict["download_url"] = download_url
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if type is not UNSET:
+        if not isinstance(type, Unset):
             field_dict["type"] = type
-        if namespace is not UNSET:
+        if not isinstance(namespace, Unset):
             field_dict["namespace"] = namespace
-        if purl is not UNSET:
+        if not isinstance(purl, Unset):
             field_dict["purl"] = purl
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if related_url is not UNSET:
+        if not isinstance(related_url, Unset):
             field_dict["related_url"] = related_url
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if version is not UNSET:
+        if not isinstance(version, Unset):
             field_dict["version"] = version
-        if release is not UNSET:
+        if not isinstance(release, Unset):
             field_dict["release"] = release
-        if el_match is not UNSET:
+        if not isinstance(el_match, Unset):
             field_dict["el_match"] = el_match
-        if arch is not UNSET:
+        if not isinstance(arch, Unset):
             field_dict["arch"] = arch
-        if nvr is not UNSET:
+        if not isinstance(nvr, Unset):
             field_dict["nvr"] = nvr
-        if nevra is not UNSET:
+        if not isinstance(nevra, Unset):
             field_dict["nevra"] = nevra
-        if epoch is not UNSET:
+        if not isinstance(epoch, Unset):
             field_dict["epoch"] = epoch
-        if copyright_text is not UNSET:
+        if not isinstance(copyright_text, Unset):
             field_dict["copyright_text"] = copyright_text
-        if license_concluded is not UNSET:
+        if not isinstance(license_concluded, Unset):
             field_dict["license_concluded"] = license_concluded
-        if license_concluded_list is not UNSET:
+        if not isinstance(license_concluded_list, Unset):
             field_dict["license_concluded_list"] = license_concluded_list
-        if license_declared is not UNSET:
+        if not isinstance(license_declared, Unset):
             field_dict["license_declared"] = license_declared
-        if license_declared_list is not UNSET:
+        if not isinstance(license_declared_list, Unset):
             field_dict["license_declared_list"] = license_declared_list
-        if openlcs_scan_url is not UNSET:
+        if not isinstance(openlcs_scan_url, Unset):
             field_dict["openlcs_scan_url"] = openlcs_scan_url
-        if openlcs_scan_version is not UNSET:
+        if not isinstance(openlcs_scan_version, Unset):
             field_dict["openlcs_scan_version"] = openlcs_scan_version
-        if software_build is not UNSET:
+        if not isinstance(software_build, Unset):
             field_dict["software_build"] = software_build
-        if errata is not UNSET:
+        if not isinstance(errata, Unset):
             field_dict["errata"] = errata
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if sources is not UNSET:
+        if not isinstance(sources, Unset):
             field_dict["sources"] = sources
-        if provides is not UNSET:
+        if not isinstance(provides, Unset):
             field_dict["provides"] = provides
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if manifest is not UNSET:
+        if not isinstance(manifest, Unset):
             field_dict["manifest"] = manifest
-        if filename is not UNSET:
+        if not isinstance(filename, Unset):
             field_dict["filename"] = filename
 
         return field_dict
@@ -472,77 +472,77 @@ class Component(ComponentRegistryModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if download_url is not UNSET:
+        if not isinstance(download_url, Unset):
             field_dict["download_url"] = download_url
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if type is not UNSET:
+        if not isinstance(type, Unset):
             field_dict["type"] = type
-        if namespace is not UNSET:
+        if not isinstance(namespace, Unset):
             field_dict["namespace"] = namespace
-        if purl is not UNSET:
+        if not isinstance(purl, Unset):
             field_dict["purl"] = purl
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if related_url is not UNSET:
+        if not isinstance(related_url, Unset):
             field_dict["related_url"] = related_url
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if version is not UNSET:
+        if not isinstance(version, Unset):
             field_dict["version"] = version
-        if release is not UNSET:
+        if not isinstance(release, Unset):
             field_dict["release"] = release
-        if el_match is not UNSET:
+        if not isinstance(el_match, Unset):
             field_dict["el_match"] = el_match
-        if arch is not UNSET:
+        if not isinstance(arch, Unset):
             field_dict["arch"] = arch
-        if nvr is not UNSET:
+        if not isinstance(nvr, Unset):
             field_dict["nvr"] = nvr
-        if nevra is not UNSET:
+        if not isinstance(nevra, Unset):
             field_dict["nevra"] = nevra
-        if epoch is not UNSET:
+        if not isinstance(epoch, Unset):
             field_dict["epoch"] = epoch
-        if copyright_text is not UNSET:
+        if not isinstance(copyright_text, Unset):
             field_dict["copyright_text"] = copyright_text
-        if license_concluded is not UNSET:
+        if not isinstance(license_concluded, Unset):
             field_dict["license_concluded"] = license_concluded
-        if license_concluded_list is not UNSET:
+        if not isinstance(license_concluded_list, Unset):
             field_dict["license_concluded_list"] = license_concluded_list
-        if license_declared is not UNSET:
+        if not isinstance(license_declared, Unset):
             field_dict["license_declared"] = license_declared
-        if license_declared_list is not UNSET:
+        if not isinstance(license_declared_list, Unset):
             field_dict["license_declared_list"] = license_declared_list
-        if openlcs_scan_url is not UNSET:
+        if not isinstance(openlcs_scan_url, Unset):
             field_dict["openlcs_scan_url"] = openlcs_scan_url
-        if openlcs_scan_version is not UNSET:
+        if not isinstance(openlcs_scan_version, Unset):
             field_dict["openlcs_scan_version"] = openlcs_scan_version
-        if software_build is not UNSET:
+        if not isinstance(software_build, Unset):
             field_dict["software_build"] = software_build
-        if errata is not UNSET:
+        if not isinstance(errata, Unset):
             field_dict["errata"] = errata
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if sources is not UNSET:
+        if not isinstance(sources, Unset):
             field_dict["sources"] = sources
-        if provides is not UNSET:
+        if not isinstance(provides, Unset):
             field_dict["provides"] = provides
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if manifest is not UNSET:
+        if not isinstance(manifest, Unset):
             field_dict["manifest"] = manifest
-        if filename is not UNSET:
+        if not isinstance(filename, Unset):
             field_dict["filename"] = filename
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/controlled_access_test_retrieve_response_200.py
+++ b/component_registry_bindings/bindings/python_client/models/controlled_access_test_retrieve_response_200.py
@@ -19,7 +19,7 @@ class ControlledAccessTestRetrieveResponse200(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if user is not UNSET:
+        if not isinstance(user, Unset):
             field_dict["user"] = user
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_channel_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_channel_list.py
@@ -34,13 +34,13 @@ class PaginatedChannelList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_component_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_component_list.py
@@ -34,13 +34,13 @@ class PaginatedComponentList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_product_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_product_list.py
@@ -34,13 +34,13 @@ class PaginatedProductList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_product_stream_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_product_stream_list.py
@@ -34,13 +34,13 @@ class PaginatedProductStreamList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_product_variant_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_product_variant_list.py
@@ -34,13 +34,13 @@ class PaginatedProductVariantList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_product_version_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_product_version_list.py
@@ -34,13 +34,13 @@ class PaginatedProductVersionList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/paginated_software_build_list.py
+++ b/component_registry_bindings/bindings/python_client/models/paginated_software_build_list.py
@@ -34,13 +34,13 @@ class PaginatedSoftwareBuildList(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/product.py
+++ b/component_registry_bindings/bindings/python_client/models/product.py
@@ -95,33 +95,33 @@ class Product(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ofuri is not UNSET:
+        if not isinstance(ofuri, Unset):
             field_dict["ofuri"] = ofuri
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if build_count is not UNSET:
+        if not isinstance(build_count, Unset):
             field_dict["build_count"] = build_count
-        if builds is not UNSET:
+        if not isinstance(builds, Unset):
             field_dict["builds"] = builds
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/product_stream.py
+++ b/component_registry_bindings/bindings/python_client/models/product_stream.py
@@ -139,49 +139,49 @@ class ProductStream(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ofuri is not UNSET:
+        if not isinstance(ofuri, Unset):
             field_dict["ofuri"] = ofuri
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if build_count is not UNSET:
+        if not isinstance(build_count, Unset):
             field_dict["build_count"] = build_count
-        if builds is not UNSET:
+        if not isinstance(builds, Unset):
             field_dict["builds"] = builds
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if cpe is not UNSET:
+        if not isinstance(cpe, Unset):
             field_dict["cpe"] = cpe
-        if active is not UNSET:
+        if not isinstance(active, Unset):
             field_dict["active"] = active
-        if brew_tags is not UNSET:
+        if not isinstance(brew_tags, Unset):
             field_dict["brew_tags"] = brew_tags
-        if yum_repositories is not UNSET:
+        if not isinstance(yum_repositories, Unset):
             field_dict["yum_repositories"] = yum_repositories
-        if composes is not UNSET:
+        if not isinstance(composes, Unset):
             field_dict["composes"] = composes
-        if et_product_versions is not UNSET:
+        if not isinstance(et_product_versions, Unset):
             field_dict["et_product_versions"] = et_product_versions
-        if manifest is not UNSET:
+        if not isinstance(manifest, Unset):
             field_dict["manifest"] = manifest
-        if relations is not UNSET:
+        if not isinstance(relations, Unset):
             field_dict["relations"] = relations
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/product_variant.py
+++ b/component_registry_bindings/bindings/python_client/models/product_variant.py
@@ -111,35 +111,35 @@ class ProductVariant(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ofuri is not UNSET:
+        if not isinstance(ofuri, Unset):
             field_dict["ofuri"] = ofuri
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if build_count is not UNSET:
+        if not isinstance(build_count, Unset):
             field_dict["build_count"] = build_count
-        if builds is not UNSET:
+        if not isinstance(builds, Unset):
             field_dict["builds"] = builds
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if relations is not UNSET:
+        if not isinstance(relations, Unset):
             field_dict["relations"] = relations
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/product_version.py
+++ b/component_registry_bindings/bindings/python_client/models/product_version.py
@@ -99,33 +99,33 @@ class ProductVersion(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ofuri is not UNSET:
+        if not isinstance(ofuri, Unset):
             field_dict["ofuri"] = ofuri
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if description is not UNSET:
+        if not isinstance(description, Unset):
             field_dict["description"] = description
-        if build_count is not UNSET:
+        if not isinstance(build_count, Unset):
             field_dict["build_count"] = build_count
-        if builds is not UNSET:
+        if not isinstance(builds, Unset):
             field_dict["builds"] = builds
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
-        if upstreams is not UNSET:
+        if not isinstance(upstreams, Unset):
             field_dict["upstreams"] = upstreams
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/software_build.py
+++ b/component_registry_bindings/bindings/python_client/models/software_build.py
@@ -72,27 +72,27 @@ class SoftwareBuild(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if not isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if web_url is not UNSET:
+        if not isinstance(web_url, Unset):
             field_dict["web_url"] = web_url
-        if build_id is not UNSET:
+        if not isinstance(build_id, Unset):
             field_dict["build_id"] = build_id
-        if build_type is not UNSET:
+        if not isinstance(build_type, Unset):
             field_dict["build_type"] = build_type
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if source is not UNSET:
+        if not isinstance(source, Unset):
             field_dict["source"] = source
-        if tags is not UNSET:
+        if not isinstance(tags, Unset):
             field_dict["tags"] = tags
-        if created_at is not UNSET:
+        if not isinstance(created_at, Unset):
             field_dict["created_at"] = created_at
-        if last_changed is not UNSET:
+        if not isinstance(last_changed, Unset):
             field_dict["last_changed"] = last_changed
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/software_build_summary.py
+++ b/component_registry_bindings/bindings/python_client/models/software_build_summary.py
@@ -33,15 +33,15 @@ class SoftwareBuildSummary(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if link is not UNSET:
+        if not isinstance(link, Unset):
             field_dict["link"] = link
-        if build_id is not UNSET:
+        if not isinstance(build_id, Unset):
             field_dict["build_id"] = build_id
-        if build_type is not UNSET:
+        if not isinstance(build_type, Unset):
             field_dict["build_type"] = build_type
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if source is not UNSET:
+        if not isinstance(source, Unset):
             field_dict["source"] = source
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/tag.py
+++ b/component_registry_bindings/bindings/python_client/models/tag.py
@@ -28,11 +28,11 @@ class Tag(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if not isinstance(name, Unset):
             field_dict["name"] = name
-        if created_at is not UNSET:
+        if not isinstance(created_at, Unset):
             field_dict["created_at"] = created_at
-        if value is not UNSET:
+        if not isinstance(value, Unset):
             field_dict["value"] = value
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/token_auth_test_create_response_200.py
+++ b/component_registry_bindings/bindings/python_client/models/token_auth_test_create_response_200.py
@@ -19,7 +19,7 @@ class TokenAuthTestCreateResponse200(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if user is not UNSET:
+        if not isinstance(user, Unset):
             field_dict["user"] = user
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/token_auth_test_retrieve_response_200.py
+++ b/component_registry_bindings/bindings/python_client/models/token_auth_test_retrieve_response_200.py
@@ -19,7 +19,7 @@ class TokenAuthTestRetrieveResponse200(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if user is not UNSET:
+        if not isinstance(user, Unset):
             field_dict["user"] = user
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200.py
@@ -36,13 +36,13 @@ class V1StatusListResponse200(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if not isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if not isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if not isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item.py
@@ -101,31 +101,31 @@ class V1StatusListResponse200ResultsItem(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if status is not UNSET:
+        if not isinstance(status, Unset):
             field_dict["status"] = status
-        if dt is not UNSET:
+        if not isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if service_version is not UNSET:
+        if not isinstance(service_version, Unset):
             field_dict["service_version"] = service_version
-        if rest_api_version is not UNSET:
+        if not isinstance(rest_api_version, Unset):
             field_dict["rest_api_version"] = rest_api_version
-        if db_size is not UNSET:
+        if not isinstance(db_size, Unset):
             field_dict["db_size"] = db_size
-        if builds is not UNSET:
+        if not isinstance(builds, Unset):
             field_dict["builds"] = builds
-        if products is not UNSET:
+        if not isinstance(products, Unset):
             field_dict["products"] = products
-        if product_versions is not UNSET:
+        if not isinstance(product_versions, Unset):
             field_dict["product_versions"] = product_versions
-        if product_streams is not UNSET:
+        if not isinstance(product_streams, Unset):
             field_dict["product_streams"] = product_streams
-        if product_variants is not UNSET:
+        if not isinstance(product_variants, Unset):
             field_dict["product_variants"] = product_variants
-        if channels is not UNSET:
+        if not isinstance(channels, Unset):
             field_dict["channels"] = channels
-        if components is not UNSET:
+        if not isinstance(components, Unset):
             field_dict["components"] = components
-        if relations is not UNSET:
+        if not isinstance(relations, Unset):
             field_dict["relations"] = relations
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_builds.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_builds.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemBuilds(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_channels.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_channels.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemChannels(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_components.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_components.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemComponents(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_streams.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_streams.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemProductStreams(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_variants.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_variants.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemProductVariants(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_versions.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_product_versions.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemProductVersions(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_products.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_products.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemProducts(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_relations.py
+++ b/component_registry_bindings/bindings/python_client/models/v1_status_list_response_200_results_item_relations.py
@@ -19,7 +19,7 @@ class V1StatusListResponse200ResultsItemRelations(ComponentRegistryModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if not isinstance(count, Unset):
             field_dict["count"] = count
 
         return field_dict

--- a/component_registry_bindings/templates/model.py.jinja
+++ b/component_registry_bindings/templates/model.py.jinja
@@ -2,7 +2,7 @@
     This is a custom template derived from:
     https://github.com/openapi-generators/openapi-python-client/blob/v.0.10.7/openapi_python_client/templates/model.py.jinja
 #}
-from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, Union
 
 {% if model.additional_properties %}
 from typing import List
@@ -75,7 +75,7 @@ field_dict.update(self.additional_properties)
 {% endif %}
 {% endif %}
 {% for property in  model.required_properties + model.optional_properties %}
-if {{ property.python_name }} is not UNSET:
+if not isinstance({{ property.python_name }}, Unset):
     field_dict["{{ property.name }}"] = {{ property.python_name }}
 {% endfor %}
 


### PR DESCRIPTION
In some cases (mainly when using multiprocessing) it occurred that were multiple instances of `Unset` and since the `to_dict` method was checking for direct equality, it broke the transformation as it kept the `Unset` values. This PR changes the direct equality check for `isinstance` check so bindings models from different processes and from different sessions may be used together.