### PR TITLE
Fix double underscore query keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- fix usage of query parameters with double underscore
 
 ## [1.3.9] - 2023-08-25
 ### Changed

--- a/component_registry_bindings/session.py
+++ b/component_registry_bindings/session.py
@@ -34,12 +34,35 @@ MAX_CONCURRENCY = get_env(
 )
 
 
+def double_underscores_to_single_underscores(fn):
+    """
+    Function decorator which changes all the keyword arguments which include
+    double underscore to use single underscore instead.
+
+    eg. affect__affectedness -> affect_affectedness
+
+    This change is needed because in OpenAPI schema query parameters might contain
+    double underscore, howerver OpenAPI Python Client package converts all these
+    double underscores into single ones and thus this creates a confusion as user
+    tries to use query parameter from the OpenAPI schema specification unaware of
+    the underscore change.
+    """
+
+    def inner(*args, **kwargs):
+        new_kwargs = {name.replace("__", "_"): value for name, value in kwargs.items()}
+        return fn(*args, **new_kwargs)
+
+    return inner
+
+
 def get_sync_function(api_module: ModuleType) -> Callable:
     """
     Get 'sync' function from API module if available (response example is defined in schema)
     or get basic 'sync_detailed' function (response example is not defined in schema)
     """
-    return getattr(api_module, "sync", getattr(api_module, "sync_detailed"))
+    return double_underscores_to_single_underscores(
+        getattr(api_module, "sync", getattr(api_module, "sync_detailed"))
+    )
 
 
 def get_async_function(api_module: ModuleType) -> Callable:
@@ -47,7 +70,9 @@ def get_async_function(api_module: ModuleType) -> Callable:
     Get 'sync' function from API module if available (response example is defined in schema)
     or get basic 'sync_detailed' function (response example is not defined in schema)
     """
-    return getattr(api_module, "async_", getattr(api_module, "async_detailed"))
+    return double_underscores_to_single_underscores(
+        getattr(api_module, "async_", getattr(api_module, "async_detailed"))
+    )
 
 
 def new_session(


### PR DESCRIPTION
API query parameters may have double underscores however OpenAPI client uses single underscore in the generated client instead. This fixes the same issue as described in the osidb-bindings issue https://github.com/RedHatProductSecurity/osidb-bindings/issues/17.