### PR TITLE
remove strtobool, removed in python-3.12

### DIFF
--- a/component_registry_bindings/helpers.py
+++ b/component_registry_bindings/helpers.py
@@ -2,12 +2,32 @@
 component-registry-bindings helpers
 """
 import json
-from distutils.util import strtobool
 from os import getenv
 from typing import Any, Union
 
 from .exceptions import ComponentRegistryBindingsException
 
+_MAP = {
+    "y": True,
+    "yes": True,
+    "t": True,
+    "true": True,
+    "on": True,
+    "1": True,
+    "n": False,
+    "no": False,
+    "f": False,
+    "false": False,
+    "off": False,
+    "0": False,
+}
+
+
+def strtobool(value):
+    try:
+        return _MAP[str(value).lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))
 
 def get_env(
     key: str,


### PR DESCRIPTION
distutil.strtobool was removed from python 3.12.
create a replacement function.